### PR TITLE
update setup.py, pip fails on install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     long_description=read('README.md'),
     include_package_data=True,
     install_requires=[
-        "Django >= 1.6, < 1.8",
+        "Django>=1.6,<1.8",
         "django-model-utils",
         "swampdragon",
         "swampdragon-auth"


### PR DESCRIPTION
It seems that spaces around versions are not working. The same as for main swampdragon package.
